### PR TITLE
feat(admin-actions): add user actions history view with paginatio

### DIFF
--- a/backend/src/main/java/com/backend/demo/controller/UserController.java
+++ b/backend/src/main/java/com/backend/demo/controller/UserController.java
@@ -2,7 +2,7 @@ package com.backend.demo.controller;
 
 import com.backend.demo.dto.request.AssignRolesRequest;
 import com.backend.demo.dto.request.RegisterRequest;
-import com.backend.demo.dto.request.UpdateUserRequest;
+import com.backend.demo.dto.response.UserActionResponse;
 import com.backend.demo.dto.response.UserResponse;
 import com.backend.demo.model.enums.ERole;
 import com.backend.demo.service.IUserService;
@@ -87,6 +87,10 @@ public class UserController {
         return ResponseEntity.ok(userService.assignRoles(id, request.getRoles()));
     }
 
+    @GetMapping("/actions")
+    public ResponseEntity<Page<UserActionResponse>> getUserActions(Pageable pageable) {
+        return ResponseEntity.ok(userService.getUserActions(pageable));
+    }
 
 
 }

--- a/backend/src/main/java/com/backend/demo/model/entity/UserAction.java
+++ b/backend/src/main/java/com/backend/demo/model/entity/UserAction.java
@@ -1,8 +1,15 @@
 package com.backend.demo.model.entity;
 
 import jakarta.persistence.*;
+import lombok.*;
+
 import java.time.LocalDateTime;
 
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Entity
 @Table(name = "user_actions")
 public class UserAction {
@@ -18,16 +25,4 @@ public class UserAction {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
-
-    // Getters y setters
-    public Long getId() { return id; }
-    public void setId(Long id) { this.id = id; }
-    public String getTipo() { return tipo; }
-    public void setTipo(String tipo) { this.tipo = tipo; }
-    public String getDescripcion() { return descripcion; }
-    public void setDescripcion(String descripcion) { this.descripcion = descripcion; }
-    public LocalDateTime getFecha() { return fecha; }
-    public void setFecha(LocalDateTime fecha) { this.fecha = fecha; }
-    public User getUser() { return user; }
-    public void setUser(User user) { this.user = user; }
 }

--- a/backend/src/main/java/com/backend/demo/service/IUserService.java
+++ b/backend/src/main/java/com/backend/demo/service/IUserService.java
@@ -3,6 +3,7 @@ package com.backend.demo.service;
 import com.backend.demo.dto.request.RegisterRequest;
 import com.backend.demo.dto.response.UserResponse;
 import com.backend.demo.model.enums.ERole;
+import com.backend.demo.dto.response.UserActionResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -25,4 +26,6 @@ public interface IUserService {
     UserResponse deactivateUser(Long id);
 
     UserResponse assignRoles(Long id, Set<String> roles);
+
+    Page<UserActionResponse> getUserActions(Pageable pageable);
 }

--- a/backend/src/main/java/com/backend/demo/service/impl/UserServiceImpl.java
+++ b/backend/src/main/java/com/backend/demo/service/impl/UserServiceImpl.java
@@ -105,7 +105,7 @@ public class UserServiceImpl implements IUserService {
         return userMapper.toResponse(userRepository.save(user));
     }
 
-    
+
     // MÉTODOS PRIVADOS
 
     private User findUserById(Long id) {
@@ -126,5 +126,15 @@ public class UserServiceImpl implements IUserService {
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Rol no válido: " + name);
         }
+    }
+
+    @Override
+    public Page<UserActionResponse> getUserActions(Pageable pageable) {
+        return userActionRepository.findAll(pageable)
+                .map(action -> new UserActionResponse(
+                        action.getUser().getEmail(),
+                        action.getAction(),
+                        action.getCreatedAt()
+                ));
     }
 }


### PR DESCRIPTION
## Descripción
Se implementa la vista de historial de acciones de usuarios para administradores, permitiendo monitorear el comportamiento del sistema de forma clara y ordenada.

## Cambios realizados
- Se crea la vista `UserActionsPage`
- Se integra el endpoint `/api/users/actions`
- Se implementa paginación de resultados
- Se muestra mensaje cuando no existen registros
- Se restringe el acceso solo a usuarios con rol ADMIN mediante `RequireAdmin`
- Se agrega protección de rutas en el frontend

## Cómo probar
1. Iniciar sesión con un usuario administrador
2. Navegar a `/admin/actions`
3. Verificar:
   - Listado de acciones
   - Paginación funcional
   - Formato de fecha correcto
4. Intentar acceder con usuario no administrador y verificar redirección a `/app`

## Issue relacionado
Closes #52
