### PR TITLE
feat: implementar vista de historial de acciones con paginación y res…

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,32 +6,32 @@ import { LoginPage } from "./pages/LoginPage";
 import { RegisterPage } from "./pages/RegisterPage";
 import { useAuth } from "./auth/AuthContext";
 import { UsersAdminPage } from "./pages/UsersAdminPage";
+import { UserActionsPage } from "./pages/UserActionsPage";
+import { RequireAdmin } from "./auth/RequireAdmin";
 
 export default function App() {
   const { isAuthenticated } = useAuth();
 
   return (
     <Routes>
-      <Route path="/" element={<Navigate to={isAuthenticated ? "/app" : "/login"} replace />} />
+      <Route
+        path="/"
+        element={<Navigate to={isAuthenticated ? "/app" : "/login"} replace />}
+      />
 
       <Route path="/login" element={<LoginPage />} />
       <Route path="/register" element={<RegisterPage />} />
       <Route path="/forgot-password" element={<ForgotPasswordPage />} />
 
-      <Route element= {<ProtectedRoute/>}>
-        <Route
-          path="/app"
-          element={
-            <AppHome />}
-        />
+      {/* Rutas protegidas (login) */}
+      <Route element={<ProtectedRoute />}>
+        <Route path="/app" element={<AppHome />} />
 
-        <Route
-          path="/admin/users"
-          element={
-            <UsersAdminPage />
-          }
-        />
-
+        {/* SOLO ADMIN */}
+        <Route element={<RequireAdmin />}>
+          <Route path="/admin/users" element={<UsersAdminPage />} />
+          <Route path="/admin/actions" element={<UserActionsPage />} />
+        </Route>
       </Route>
 
       <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/api/userActions.ts
+++ b/frontend/src/api/userActions.ts
@@ -1,0 +1,28 @@
+import { http } from "./http";
+
+export type UserAction = {
+  usuario: string;
+  accion: string;
+  fecha: string; // viene como ISO string
+};
+
+export type PageResponse<T> = {
+  content: T[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+  first: boolean;
+  last: boolean;
+};
+
+export async function getUserActions(params: {
+  page: number;
+  size: number;
+}): Promise<PageResponse<UserAction>> {
+  const { data } = await http.get<PageResponse<UserAction>>(
+    "/api/users/actions",
+    { params }
+  );
+  return data;
+}

--- a/frontend/src/auth/RequireAdmin.tsx
+++ b/frontend/src/auth/RequireAdmin.tsx
@@ -1,0 +1,33 @@
+import { Navigate, Outlet } from "react-router-dom";
+
+function parseJwt(token: string): any | null {
+  try {
+    const base64Payload = token.split(".")[1];
+    if (!base64Payload) return null;
+
+    const decoded = atob(base64Payload);
+    return JSON.parse(decoded);
+  } catch (e) {
+    return null;
+  }
+}
+
+function isAdmin(): boolean {
+  const token = localStorage.getItem("auth_token");
+  if (!token) return false;
+
+  const payload = parseJwt(token);
+  if (!payload) return false;
+
+  // para distintos formatos de roles
+  const roles = payload.roles || payload.authorities || [];
+
+  return Array.isArray(roles) && roles.includes("ROLE_ADMIN");
+}
+
+export function RequireAdmin() {
+  if (!isAdmin()) {
+    return <Navigate to="/app" replace />;
+  }
+  return <Outlet />;
+}

--- a/frontend/src/pages/UserActionsPage.tsx
+++ b/frontend/src/pages/UserActionsPage.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from "react";
+import { getUserActions, type UserAction } from "../api/userActions";
+
+export function UserActionsPage() {
+  const [page, setPage] = useState(0);
+  const [size, setSize] = useState(10);
+
+  const [data, setData] = useState<{
+    actions: UserAction[];
+    totalPages: number;
+    totalElements: number;
+  } | null>(null);
+
+  const [loading, setLoading] = useState(false);
+
+  async function load() {
+    try {
+      setLoading(true);
+      const res = await getUserActions({ page, size });
+
+      setData({
+        actions: res.content,
+        totalPages: res.totalPages,
+        totalElements: res.totalElements,
+      });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, [page, size]);
+
+  return (
+    <div style={{ maxWidth: 1000, margin: "30px auto", padding: 12 }}>
+      <h2>Historial de acciones</h2>
+
+      {/* PAGINACIÓN */}
+      <div style={{ display: "flex", gap: 10, marginBottom: 10 }}>
+        <button disabled={page === 0} onClick={() => setPage((p) => p - 1)}>
+          Anterior
+        </button>
+
+        <div>
+          Página {page + 1} / {data?.totalPages ?? 1}
+        </div>
+
+        <button
+          disabled={!data || page + 1 >= data.totalPages}
+          onClick={() => setPage((p) => p + 1)}
+        >
+          Siguiente
+        </button>
+
+        <div style={{ marginLeft: "auto" }}>
+          <select value={size} onChange={(e) => setSize(Number(e.target.value))}>
+            <option value={5}>5</option>
+            <option value={10}>10</option>
+            <option value={20}>20</option>
+          </select>
+        </div>
+      </div>
+
+      {/* TABLA */}
+      {loading && <div>Cargando...</div>}
+
+      {!loading && data && data.actions.length === 0 && (
+        <div>No hay registros de acciones.</div>
+      )}
+
+      {!loading && data && data.actions.length > 0 && (
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead>
+            <tr>
+              <th>Usuario</th>
+              <th>Acción</th>
+              <th>Fecha</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.actions.map((a, i) => (
+              <tr key={i}>
+                <td>{a.usuario}</td>
+                <td>{a.accion}</td>
+                <td>{new Date(a.fecha).toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Descripción
Se implementa la vista de historial de acciones de usuarios para administradores, permitiendo monitorear el comportamiento del sistema de forma clara y ordenada.

## Cambios realizados
- Se crea la vista `UserActionsPage`
- Se integra el endpoint `/api/users/actions`
- Se implementa paginación de resultados
- Se muestra mensaje cuando no existen registros
- Se restringe el acceso solo a usuarios con rol ADMIN mediante `RequireAdmin`
- Se agrega protección de rutas en el frontend

## Cómo probar
1. Iniciar sesión con un usuario administrador
2. Navegar a `/admin/actions`
3. Verificar:
   - Listado de acciones
   - Paginación funcional
   - Formato de fecha correcto
4. Intentar acceder con usuario no administrador y verificar redirección a `/app`

## Issue relacionado
Closes #52 