### PR TITLE
fix: corregir validación de creación de eventos

### DIFF
--- a/backend/src/main/java/com/backend/demo/dto/request/CreateEventRequest.java
+++ b/backend/src/main/java/com/backend/demo/dto/request/CreateEventRequest.java
@@ -43,7 +43,5 @@ public class CreateEventRequest {
     @Min(value = 0, message = "Los cupos de parqueadero no pueden ser negativos")
     private Integer parkingSpots = 0;
 
-    @NotNull(message = "El ID del creador es obligatorio")
-    private Long createdById;
 
 }


### PR DESCRIPTION
##  Cambios realizados
- Se eliminó el campo createdById del request
- Se corrigió la validación en CreateEventRequest
- Se ajustó la lógica de createEvent para usar usuario autenticado

##  Problema
Se generaba error 400/500 al crear eventos debido a validación incorrecta.

##  Resultado
Ahora los eventos se crean correctamente usando el usuario autenticado.