### PR TITLE
ci: agregar pipeline CI con tests y secrets SMTP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+    branches:
+      - develop
+      - main
+
+jobs:
+  build-and-test:
+    name: Build y Test Backend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout codigo
+        uses: actions/checkout@v4
+
+      - name: Configurar Java 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Maven
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Compilar proyecto
+        working-directory: backend
+        run: ./mvnw clean compile -DskipTests
+
+      - name: Ejecutar tests
+        working-directory: backend
+        env:
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+        run: ./mvnw test -Dspring.profiles.active=test


### PR DESCRIPTION
Se configura el pipeline CI con GitHub Actions para automatizar la compilación y ejecución de tests del backend. Se agregan los secrets SMTP (SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS) al repositorio para inyectarlos de forma segura en el workflow sin exponer credenciales en el código. El pipeline se activa automáticamente en cada push y PR a develop y main, bloqueando el merge si el build falla.
closes #90 