### PR TITLE
fix: agregar permisos de ejecucion a mvnw en pipeline CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      - name: Dar permisos a mvnw
+        working-directory: backend
+        run: chmod +x mvnw
+
       - name: Compilar proyecto
         working-directory: backend
         run: ./mvnw clean compile -DskipTests


### PR DESCRIPTION
Fix: se agrega permiso de ejecución al archivo mvnw para que el pipeline CI pueda correr correctamente en el entorno Linux de GitHub Actions.