### PR TITLE
ci: agregar pipeline de build automatizado para backend y frontend 

### DIFF
--- a/.github/workflows/automated-build.yml
+++ b/.github/workflows/automated-build.yml
@@ -1,0 +1,93 @@
+name: Automated Build
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+    branches:
+      - develop
+      - main
+
+jobs:
+  build-backend:
+    name: Build Backend - Generar JAR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout codigo
+        uses: actions/checkout@v4
+
+      - name: Configurar Java 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Compilar y generar JAR
+        working-directory: backend
+        run: mvn clean package -DskipTests
+
+      - name: Verificar JAR generado
+        run: |
+          echo "===== ARTEFACTO BACKEND ====="
+          ls -lh backend/target/*.jar
+
+      - name: Subir JAR como artefacto
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-jar
+          path: backend/target/*.jar
+          retention-days: 7
+
+  build-frontend:
+    name: Build Frontend - Compilar React
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout codigo
+        uses: actions/checkout@v4
+
+      - name: Configurar Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Instalar dependencias
+        working-directory: frontend
+        run: npm ci
+
+      - name: Compilar frontend
+        working-directory: frontend
+        run: npm run build
+
+      - name: Verificar build generado
+        run: |
+          echo "===== ARTEFACTO FRONTEND ====="
+          ls -lh frontend/dist/
+
+      - name: Subir build como artefacto
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-build
+          path: frontend/dist/
+          retention-days: 7
+
+  build-summary:
+    name: Resumen de builds
+    runs-on: ubuntu-latest
+    needs: [build-backend, build-frontend]
+
+    steps:
+      - name: Mostrar resumen
+        run: |
+          echo "===== BUILDS COMPLETADOS ====="
+          echo "Backend JAR: generado correctamente"
+          echo "Frontend dist: generado correctamente"
+          echo "Rama: ${{ github.ref_name }}"
+          echo "Commit: ${{ github.sha }}"
+          echo "Actor: ${{ github.actor }}"


### PR DESCRIPTION
Se configura el pipeline de construcción automatizada para backend y frontend. 
El backend genera el artefacto JAR con Maven y el frontend compila con Vite. 
Ambos artefactos quedan disponibles para descarga en GitHub Actions por 7 días. 
El pipeline falla automáticamente si cualquier build no es exitoso.
closes #103 