### PR TITLE
fix(security): allow actuator health endpoint access

### DIFF
--- a/backend/src/main/java/com/backend/demo/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/backend/demo/security/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
                                 "/api/users/register",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
-                                "/actuator/health"
+                                "/actuator/**"
                         ).permitAll()
                         .requestMatchers("/api/v1/ai/**").permitAll()
                         .anyRequest().authenticated()


### PR DESCRIPTION
## Descripción

Se ajustó la configuración de Spring Security para permitir acceso público al endpoint:

`/actuator/**`

## Objetivo

Corregir el fallo del health check en el pipeline CD, el cual respondía:

`HTTP 401 Unauthorized`


