### PR TITLE
feat(database): agregar scheduler preventivo de suspensión de BD

### DIFF
--- a/backend/src/main/java/com/backend/demo/DemoApplication.java
+++ b/backend/src/main/java/com/backend/demo/DemoApplication.java
@@ -3,11 +3,13 @@ package com.backend.demo;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
 @EnableAsync
 @EnableRetry
+@EnableScheduling
 public class DemoApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/backend/demo/config/DatabaseKeepAliveScheduler.java
+++ b/backend/src/main/java/com/backend/demo/config/DatabaseKeepAliveScheduler.java
@@ -1,0 +1,29 @@
+package com.backend.demo.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DatabaseKeepAliveScheduler {
+
+    private static final Logger logger = LoggerFactory.getLogger(DatabaseKeepAliveScheduler.class);
+    private final JdbcTemplate jdbcTemplate;
+
+    public DatabaseKeepAliveScheduler(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    // Ejecutar cada 20 minutos (1200000 ms) para mantener la base de datos de Supabase activa
+    @Scheduled(fixedRate = 1200000)
+    public void pingDatabase() {
+        try {
+            jdbcTemplate.execute("SELECT 1");
+            logger.info("Ping a la base de datos ejecutado correctamente para evitar suspensión.");
+        } catch (Exception e) {
+            logger.error("Error al ejecutar ping de base de datos", e);
+        }
+    }
+}


### PR DESCRIPTION
- Habilita @EnableScheduling en DemoApplication.

- Añade DatabaseKeepAliveScheduler para ejecutar 'SELECT 1' cada 20 minutos.

- Previene que la capa gratuita de Supabase pause la base de datos por inactividad.